### PR TITLE
fix module path resolution logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ const ui5require = require('ui5-simple-require').ui5require;
 
 API.inject('/src/main/webapp/money/CurrencyServer', FakeCurrencyServer);
 
-const MoneyChanger = ui5require('/src/main/webapp/money/changer');
-const Note = ui5require('/src/main/webapp/money/note');
-const Coin = ui5require('/src/main/webapp/money/coin');
+const MoneyChanger = ui5require('./src/main/webapp/money/changer');
+const Note = ui5require('./src/main/webapp/money/note');
+const Coin = ui5require('./src/main/webapp/money/coin');
 
 describe("Should test money changer", () => {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -432,8 +432,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1155,6 +1154,17 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "parent-module": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+          "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0"
+          }
+        }
       }
     },
     "imurmurhash": {
@@ -2120,12 +2130,11 @@
       }
     },
     "parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
       "requires": {
-        "callsites": "^3.0.0"
+        "callsites": "^3.1.0"
       }
     },
     "path-exists": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     {
       "name": "Nathan Schneider",
       "email": "nsschneider1@gmail.com"
+    },
+    {
+      "name": "Yuping Zuo",
+      "url": "https://github.com/zypA133510"
     }
   ],
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "./node_modules/mocha/bin/mocha test/*Test.js",
+    "test": "mocha test/*Test.js",
     "coverage": "nyc npm run test",
-    "test:debug": "./node_modules/mocha/bin/mocha --inspect-brk test/*Test.js",
-    "testwatcher": "node node_modules/mocha/bin/mocha test/*Test.js --colors --recursive --watch"
+    "test:debug": "mocha --inspect-brk test/*Test.js",
+    "testwatcher": "mocha test/*Test.js --colors --recursive --watch"
   },
   "keywords": [
     "mocha",
@@ -39,6 +39,7 @@
     "sinon-chai": "^3.4.0"
   },
   "dependencies": {
-    "deepmerge": "^4.2.2"
+    "deepmerge": "^4.2.2",
+    "parent-module": "^2.0.0"
   }
 }

--- a/src/UI5ModuleLoader.js
+++ b/src/UI5ModuleLoader.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require("path");
+const getCaller = require("parent-module");
 
 module.exports = {
   _removeFromCacheIfExists: function(modulePath) {
@@ -23,9 +24,11 @@ module.exports = {
       }
     };
 
-    const requirePath = path.resolve(".") + path.normalize(file + ".js");
+    const mainScript = require.resolve("../index.js");
+    const callerDir = path.dirname(getCaller(mainScript));
+    const requirePath = require.resolve(file, {paths: [callerDir]});
     this._removeFromCacheIfExists(requirePath);
-    require(path.resolve(".") + file);
+    require(requirePath);
     delete global["sap"];
     this._removeFromCacheIfExists(requirePath);
     return importedModule;

--- a/test/apiTest.js
+++ b/test/apiTest.js
@@ -1,11 +1,9 @@
 "use strict";
 
-const chai = require("chai");
-const expect = chai.expect;
+const {expect} = require("chai")
+  .use(require("sinon-chai"));
 const API = require("../index.js");
 const sinon = require("sinon");
-const sinonChai = require("sinon-chai");
-chai.use(sinonChai);
 
 const ui5require = API.ui5require;
 
@@ -13,30 +11,35 @@ context("API Test", () => {
 
   describe(".ui5require new api", () => {
     it("Should import library without dependencies", () => {
-      const UI5ModuleExample = ui5require("/test/example/UI5ModuleExample");
+      const UI5ModuleExample = ui5require("./example/UI5ModuleExample");
       expect(UI5ModuleExample).to.be.an("object");
     });
 
     it("Should import same library in a different test", () => {
-      const UI5ModuleExample = ui5require("/test/example/UI5ModuleExample");
+      const UI5ModuleExample = ui5require("./example/UI5ModuleExample");
+      expect(UI5ModuleExample).to.be.an("object");
+    });
+
+    it("Should import library with absolute path", () => {
+      const UI5ModuleExample = ui5require(require.resolve("./example/UI5ModuleExample"));
       expect(UI5ModuleExample).to.be.an("object");
     });
 
     it("Should import module with behavior", () => {
-      const m = ui5require("/test/example/UI5ModuleWithBehavior");
+      const m = ui5require("./example/UI5ModuleWithBehavior");
       expect(m).to.be.an("object");
       expect(m.behavior()).to.equal("result");
     });
 
     it("Should import library and inject dependency values", () => {
       API.inject("/path/to/dependency", { injectedValue: "abc" });
-      const m = ui5require("/test/example/UI5InjectionExample");
+      const m = ui5require("./example/UI5InjectionExample");
       expect(m).to.be.an("object");
       expect(m.dep).to.be.equal("abc");
     });
 
     it("COMPATIBILITY: Should import library and inject dependency via position parameter", () => {
-      const m = ui5require("/test/example/UI5InjectionExample", [{ injectedValue: "cba" }]);
+      const m = ui5require("./example/UI5InjectionExample", [{ injectedValue: "cba" }]);
       expect(m).to.be.an("object");
       expect(m.dep).to.be.equal("cba");
     });
@@ -44,7 +47,7 @@ context("API Test", () => {
     it("Should import multiple dependencies", () => {
       API.inject("/path/to/dependency1", { injectedValue: "abc" });
       API.inject("/path/to/dependency2", { injectedValue: "cba" });
-      const m = ui5require("/test/example/UI5MultipleInjectionExample");
+      const m = ui5require("./example/UI5MultipleInjectionExample");
       expect(m).to.be.an("object");
       expect(m.depOne).to.be.equal("abc");
       expect(m.depTwo).to.be.equal("cba");
@@ -52,25 +55,25 @@ context("API Test", () => {
 
     it("Should import module with global context", () => {
       API.globalContext({ value: "abc" });
-      let m = ui5require("/test/example/UI5GlobalSAPExample");
+      let m = ui5require("./example/UI5GlobalSAPExample");
       expect(m).to.be.an("object");
       expect(m.value).to.be.equal("abc");
     });
 
     it("COMPATIBILITY: Should import module with global context", () => {
-      let m = ui5require("/test/example/UI5GlobalSAPExample", [], { value: "cba" });
+      let m = ui5require("./example/UI5GlobalSAPExample", [], { value: "cba" });
       expect(m).to.be.an("object");
       expect(m.value).to.be.equal("cba");
     });
 
     it("Should load nested module dependency", () => {
-      let m = ui5require("/test/example/UI5NestedDependencyExample");
+      let m = ui5require("./example/UI5NestedDependencyExample");
       expect(m).to.be.an("object");
       expect(m.getNestedBehavior()).to.be.equal("result");
     });
 
     it("Should be able to load two level's nested dependencies", () => {
-      let m = ui5require("/test/example/UI5TwoLevelNestedDependency");
+      let m = ui5require("./example/UI5TwoLevelNestedDependency");
       expect(m).to.be.an("object");
       expect(m.getNestedBehavior()).to.be.equal("result");
     });

--- a/test/globalContextIssueTest.js
+++ b/test/globalContextIssueTest.js
@@ -15,13 +15,13 @@ context("", function() {
 
   it("Import with global context", function() {
     API.globalContext({ value: "abc" });
-    const m = ui5require("/test/example/UI5GlobalSAPExample");
+    const m = ui5require("./example/UI5GlobalSAPExample");
     expect(m.value).to.be.equal("abc");
   });
 
   it("Import another global context", function() {
     API.globalContext({ value: "cba" });
-    const m = ui5require("/test/example/UI5GlobalSAPExample");
+    const m = ui5require("./example/UI5GlobalSAPExample");
     expect(m.value).to.be.equal("cba");
   });
 });


### PR DESCRIPTION
- path resolution now use proper path joining mechanism instead of string concatenation
- path with leading slash is now recognized as absolute path
- path resolution now follows the logic of require(), that is, if path is relative, it will now resolves relative to the directory where the caller script resides, instead of the current working directory

BREAKING CHANGE: existing API calls are expected to update the path (the first argument) they pass to this module. Calls that use deprecated old API are not affected.

Close: #4 