### PR TITLE
Fix sap.ui.require

### DIFF
--- a/src/UI5ModuleLoader.js
+++ b/src/UI5ModuleLoader.js
@@ -20,6 +20,10 @@ module.exports = {
         define: function(dep, fn) {
           importedModule.parameters = dep;
           importedModule.fn = fn;
+        },
+        require: function(dep, fn) {
+          importedModule.parameters = dep;
+          importedModule.fn = fn;
         }
       }
     };

--- a/test/apiTest.js
+++ b/test/apiTest.js
@@ -78,6 +78,15 @@ context("API Test", () => {
       expect(m.getNestedBehavior()).to.be.equal("result");
     });
 
+    it("Should execute script in sap.ui.require", () => {
+      const Stub = class Dependency {};
+      let spy = sinon.spy();
+      Stub.spiedCall = spy;
+      API.inject("/path/to/dependency", Stub);
+      ui5require("./example/UI5SapUiRequireExample");
+      expect(spy).to.have.been.calledOnce;
+    });
+
   });
 });
 

--- a/test/example/UI5SapUiRequireExample.js
+++ b/test/example/UI5SapUiRequireExample.js
@@ -1,0 +1,3 @@
+sap.ui.require(['/path/to/dependency'], function(Dependency) {
+  Dependency.spiedCall();
+});


### PR DESCRIPTION
Fix error "sap.ui.require is not a function".

See test and example for the use case.

Note to maintainer: the test in this PR needs to be updated if #5 is merged, i.e. `/test/example` in path needs to be changed to `./example`.