### PR TITLE
[docs] Add example of global DOM injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ The injected object will be under `global.sap` object. Such as:
 sap.someValue; // evaluates to "custom value"
 ```
 
+If global variable in JavaScript is required, e.g. `window.document`, you may assign it to global like this:
+
+```js
+const { JSDOM } = require('jsdom');
+
+describe('document in global scope', () => {
+  beforeEach(() => {
+    const dom = new JSDOM(`<html><body>Hello world.</body></html>`);
+    global.document = dom.window.document;
+  });
+  afterEach(() => {
+    delete global.document;
+  });
+
+  it('should be able to access document in global scope', () => {
+    let module = ui5require('./test/example/UI5GlobalDOMExample.js');
+    expect(module.getHTML()).to.equal('Hello world.');
+  });
+});
+```
+
 ## Example
 
 Using mocha and chai for writting unit tests.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Deletes any dependencies passed with `inject`
 
 #### `globalContext(context)`
 
-- `context` \<string\>
+- `context` \<Object\>
 
 
 #### `clearGlobalContext()`

--- a/test/apiTest.js
+++ b/test/apiTest.js
@@ -60,10 +60,34 @@ context("API Test", () => {
       expect(m.value).to.be.equal("abc");
     });
 
+    it.skip("Should clean up global context", () => {
+      API.globalContext({ value: "abc" });
+      ui5require("/test/example/UI5GlobalSAPExample");
+      API.clearGlobalContext();
+      expect(global.sap).to.be.undefined;
+    });
+
     it("COMPATIBILITY: Should import module with global context", () => {
       let m = ui5require("./example/UI5GlobalSAPExample", [], { value: "cba" });
       expect(m).to.be.an("object");
       expect(m.value).to.be.equal("cba");
+    });
+
+    it("Should be able to inject global variables", () => {
+      const text = "lorem ipsum dolor sit amet";
+      // one can also use jsdom here
+      let dom = {
+        title: "original",
+        body: {
+          innerHTML: text
+        }
+      };
+      global.document = dom;
+      let m = ui5require("./example/UI5GlobalDOMExample");
+      expect(m.getHTML()).to.equal(text);
+      expect(() => m.changeTitle("altered")).to.not.throw();
+      expect(dom.title).to.equal("altered");
+      delete global.document;
     });
 
     it("Should load nested module dependency", () => {

--- a/test/example/UI5GlobalDOMExample.js
+++ b/test/example/UI5GlobalDOMExample.js
@@ -1,0 +1,10 @@
+sap.ui.define([], function() {
+  return {
+    getHTML: function() {
+      return document.body.innerHTML;
+    },
+    changeTitle: function(newTitle) {
+      document.title = newTitle;
+    }
+  };
+});


### PR DESCRIPTION
- added an example of injecting DOM to global scope
- added test on global context cleanup (ref: #7)
- fixed a possible oversight in API documentation, type of `context` should be an object, not a string.

As with the previous PR, tests need to be updated if #5 is merged.